### PR TITLE
Add types for event handlers

### DIFF
--- a/src/el.ts
+++ b/src/el.ts
@@ -1,9 +1,19 @@
+interface EventHandler<T, E extends Event> {
+  (
+    e: E & {
+      currentTarget: T;
+      target: HTMLElement;
+    },
+  ): void;
+}
+
 export default function el<K extends keyof HTMLElementTagNameMap>(
   type: K,
   // pretty crazy typing huh? but it works!
   props: Partial<
-    Omit<HTMLElementTagNameMap[K], "style"> & {
+    Omit<HTMLElementTagNameMap[K], "style" | "oninput"> & {
       style: Partial<CSSStyleDeclaration>;
+      oninput?: EventHandler<HTMLElementTagNameMap[K], KeyboardEvent>;
       onMount?: (el: HTMLElementTagNameMap[K]) => void;
     }
   > = {},

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ const notesPerMinSlider = el(
     type: "range",
     style: { flexGrow: "1" },
     oninput: (e) => {
-      notesPerMinute.set(Number((e.target as HTMLInputElement).value));
+      notesPerMinute.set(e.currentTarget.valueAsNumber);
     },
     min: "15",
     max: "180",


### PR DESCRIPTION
I was curious how solidjs was able to get good typings for their event handlers when the built-in ts types for dom events are pretty poor. (For instance: just `Event` rather than specific types like `KeyboardEvent` or `MouseEvent`, and `.currentTarget` is never the known target element. It requires a type assertion.)

It turns out, they do this painstakingly by hand for every single property of every single element: https://github.com/ryansolid/dom-expressions/blob/main/packages/dom-expressions/src/jsx.d.ts

That's overkill for something as minimal as you have here, and given that there are currently zero dependencies you might not want to import `dom-expressions`. That said, it is cool to see how child nodes are added. The code is extremely terse, not the most readable, but the recursive `item` function could be something to look into stealing inspiration from: https://github.com/ryansolid/dom-expressions/blob/main/packages/hyper-dom-expressions/src/index.ts

In any case, I did find this [useful interface](https://github.com/ryansolid/dom-expressions/blob/main/packages/dom-expressions/src/jsx.d.ts#L23-L30) for defining the event handler types. You'd need to manually `Omit<...>` each additional event that you want to support, and then patch it in like I've done for `oninput`. But if you only need support for a handful of them, this approach might be reasonable?

Interested to see what you think!